### PR TITLE
Fix fatal error : require MenuCache class if composer autoloader is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.1
+
+* Fix fatal error when plugin is not used with composer autoloader
+
 ## 1.0.0
 
 * Initial release.

--- a/index.php
+++ b/index.php
@@ -5,7 +5,7 @@
  * Description: Easily cache rendered menus using the Transients API.
  * Author:      Inpsyde GmbH, Thorsten Frommen, David Naber
  * Author URI:  https://inpsyde.com
- * Version:     1.0.0
+ * Version:     1.0.1
  * License:     MIT
  */
 
@@ -32,8 +32,9 @@ function bootstrap() {
 		 * Composer-generated autoload file.
 		 */
 		require_once __DIR__ . '/vendor/autoload.php';
+	} else {
+		require_once __DIR__ . '/src/MenuCache.php';
 	}
-
 	$cache = new MenuCache();
 
 	add_filter( 'pre_wp_nav_menu', [ $cache, 'get_menu' ], 10, 2 );


### PR DESCRIPTION
<!--
Thanks for contributing&mdash;you rock!

Please note:
- These comments won't show up when you submit the pull request.
- Please make sure your changes respect the WordPress Coding Standards:
  - https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- In case you introduced a new action or filter hook, please also include inline documentation:
  - https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/
- Please create tests, if you can.
-->
#### What's Included in This Pull Request
- Fix fatal error : can not found MenuCache class in index.php because of missing require if composer autoloader is not set.
