### PR TITLE
Bypass potentially conflicting 3rd party code

### DIFF
--- a/index.php
+++ b/index.php
@@ -36,7 +36,8 @@ function bootstrap() {
 
 	$cache = new MenuCache();
 
-	add_filter( 'pre_wp_nav_menu', [ $cache, 'get_menu' ], 10, 2 );
+	// Run as early as possible. All other code here would either be a conflicting cache plugin or a misplaced attempt to initialize a menu with no way to restore after we've run. ( switch_to_blog() on this hook would be fatal )
+	add_filter( 'pre_wp_nav_menu', [ $cache, 'get_menu' ], 0, 2 );
 
 	// Unfortunately, there is no appropriate action, so we have to (mis)use a filter here. Almost as late as possible.
 	add_filter( 'wp_nav_menu', [ $cache, 'cache_menu' ], PHP_INT_MAX - 1, 2 );

--- a/src/MenuCache.php
+++ b/src/MenuCache.php
@@ -82,6 +82,8 @@ class MenuCache {
 		if ( $this->should_cache_menu( $args ) && isset( $args->{$this->key_argument} ) ) {
 			$cached_menu = get_transient( $args->{$this->key_argument} );
 			if ( is_string( $cached_menu ) ) {
+				// We have found what we need, so we don't want any code to run after us (since any changes made here would be impossible to restore)
+				remove_all_filters( 'pre_wp_nav_menu' );
 				return $cached_menu;
 			}
 		}


### PR DESCRIPTION
<!--
Thanks for contributing&mdash;you rock!

Please note:
- These comments won't show up when you submit the pull request.
- Please make sure your changes respect the WordPress Coding Standards:
  - https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- In case you introduced a new action or filter hook, please also include inline documentation:
  - https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/
- Please create tests, if you can.
-->

This pull request fixes issue #2.

#### What's Included in This Pull Request

* Hook into `pre_wp_nav_menu` as early as possible
* If a cache was found, remove all other code hooked into `pre_wp_nav_menu` since it's **probably** not supposed to be running anyway (we do have our complete cache at hand, after all)

