### PR TITLE
PHPCS/Composer: update PHPCS related dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,12 +42,12 @@
   },
   "require-dev": {
     "brain/monkey": "^1.5.0",
-    "dealerdirect/phpcodesniffer-composer-installer": "^0.4.2",
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.5",
     "mockery/mockery": "~0.9",
     "phpunit/phpunit": "~4.8|~5.1",
     "squizlabs/php_codesniffer": "^3.0",
-    "wimg/php-compatibility": "^8.0",
-    "wp-coding-standards/wpcs": "^0.13.1"
+    "wp-coding-standards/wpcs": "^2.2",
+    "phpcompatibility/phpcompatibility-wp": "^2.1"
   },
   "autoload": {
     "psr-4": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -10,7 +10,7 @@
 
 	<!-- Check for cross-version support for PHP. -->
 	<config name="testVersion" value="5.4-"/>
-	<rule ref="PHPCompatibility"/>
+	<rule ref="PHPCompatibilityWP"/>
 
 	<rule ref="WordPress">
 
@@ -24,6 +24,11 @@
 		<!-- Exclude to be able to adhere to PSR-4. -->
 		<exclude name="WordPress.Files.FileName"/>
 
+		<!-- Don't demand long arrays. -->
+		<exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
 	</rule>
+
+	<!-- Enforce short arrays. -->
+	<rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
 
 </ruleset>


### PR DESCRIPTION
* Switches the repo over to use `PHPCompatibilityWP` rather than `PHPCompatibility`.
    As this repo and ruleset is for a WordPress project, using the `PHPCompatibilityWP` ruleset is the better choice to prevent false positives for PHP functions and constants which are back-filled by WP.
* Switches the dependency over to use the repo in the `PHPCompatibility` organisation rather than the one in `wimg`'s personal account.
* Use the latest version of PHPCompatibility.
    You were missing out on a lot of new checks, including the checks to make sure your code is compatible with the upcoming PHP 7.4.
* Use the latest version of the DealerDirect Composer PHPCS plugin.
    Composer treats minors < 1.0 as majors, so you need to explicitly update.
* Use the latest version of WPCS.
    Includes minor ruleset tweak related to long vs short arrays.

Ref:
* https://github.com/PHPCompatibility/PHPCompatibilityWP
* PHPCompatibility/PHPCompatibility#688
* https://github.com/WordPress/WordPress-Coding-Standards/releases/
