### PR TITLE
Travis: fix build failure on PHP 5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
-language: php
+dist: trusty
 
-sudo: false
+language: php
 
 cache:
   apt: true


### PR DESCRIPTION
#### What's Included in This Pull Request

On the new Xenial platform, there is no image available for PHP 5.4.
By setting the platform to `trusty`, things start working again ;-)

Also removing `sudo: false` as that hasn't been supported for quite a while now on Travis.
